### PR TITLE
remove align(1)

### DIFF
--- a/traildbc.di
+++ b/traildbc.di
@@ -21,7 +21,6 @@ union tdb_opt_value
 
 struct tdb_event
 {
-align(1):
     uint64_t timestamp;
     uint64_t num_items;
     tdb_item[0] items;


### PR DESCRIPTION
align(1) do nothing here. The struct is already packed because both fields are 64-bit integers.
